### PR TITLE
Fix HTML validation of the input field

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -1,4 +1,4 @@
-/* https://github.com/vufind-org/autocomplete.js (v2.1.9) (2024-02-26) */
+/* https://github.com/vufind-org/autocomplete.js (v2.1.10) (2024-06-06) */
 function Autocomplete(_settings) {
   const _DEFAULTS = {
     delay: 250,
@@ -75,6 +75,7 @@ function Autocomplete(_settings) {
 
     clearTimeout(debounceTimeout);
     _currentIndex = -1;
+    lastInput.setAttribute('aria-expanded', 'false');
     lastInput = false;
     lastCB = null;
   }
@@ -197,6 +198,8 @@ function Autocomplete(_settings) {
       _searchCallback(items, input);
       _show(input);
       _align(input);
+      // Set aria-expanded here so that the load indicator isn't marked expanded
+      input.setAttribute('aria-expanded', 'true');
     });
   }
 
@@ -295,6 +298,7 @@ function Autocomplete(_settings) {
     list.setAttribute("role", "listbox");
     input.setAttribute("role", "combobox");
     input.setAttribute("aria-autocomplete", "both");
+    input.setAttribute('aria-expanded', 'false');
     input.setAttribute("aria-controls", list.getAttribute("id"));
     input.setAttribute("enterkeyhint", "search"); // phone keyboard hint
     input.setAttribute("autocapitalize", "off");  // disable browser tinkering

--- a/autocomplete.js
+++ b/autocomplete.js
@@ -75,7 +75,9 @@ function Autocomplete(_settings) {
 
     clearTimeout(debounceTimeout);
     _currentIndex = -1;
-    lastInput.setAttribute('aria-expanded', 'false');
+    if (lastInput) {
+      lastInput.setAttribute('aria-expanded', 'false');
+    }
     lastInput = false;
     lastCB = null;
   }
@@ -303,8 +305,10 @@ function Autocomplete(_settings) {
     input.setAttribute("enterkeyhint", "search"); // phone keyboard hint
     input.setAttribute("autocapitalize", "off");  // disable browser tinkering
     input.setAttribute("autocomplete", "off");    // ^
-    input.setAttribute("autocorrect", "off");     // ^
     input.setAttribute("spellcheck", "false");    // ^
+    if (typeof input.autocorrect !== 'undefined') {
+      input.setAttribute("autocorrect", "off");     // ^ only with Safari
+    }
 
     // Activation / De-activation
     if (input.getAttribute("autofocus") !== null) {


### PR DESCRIPTION
role="combobox" requires aria-expanded to pass HTML validation. And autocorrect is non-standard so should only be added when absolutely necessary.

This problem does not surface if you just test an HTML page as it's loaded from the server, but if you actually test the resulting HTML after the autocomplete field is initialized, you'll get the following error:
![kuva](https://github.com/vufind-org/autocomplete.js/assets/1327659/70ed46a4-5b43-4d0b-ac9b-efb1de96422d)
